### PR TITLE
add counters

### DIFF
--- a/scripts/ingests/sanghi23/IngestAllNames.py
+++ b/scripts/ingests/sanghi23/IngestAllNames.py
@@ -1,20 +1,18 @@
 # SIMPLE & Astrodb Packages
-from astrodb_utils import load_astrodb, logger
-from astrodb_utils.sources import ingest_source, find_source_in_db, ingest_name
-from astrodb_utils.publications import ingest_publication
-from simple.schema import *
+from astrodb_utils import load_astrodb, AstroDBError
+from astrodb_utils.sources import find_source_in_db, ingest_name
 from simple.schema import REFERENCE_TABLES
 import pandas as pd
 import os
-# logger.setLevel("DEBUG")
 
 # Load Database
-recreate_db = False
-save_db = True
+recreate_db = True
+save_db = False
 db = load_astrodb("SIMPLE.sqlite", recreatedb=recreate_db, reference_tables=REFERENCE_TABLES)
 path = "scripts/ingests/sanghi23/"
 
-
+names_added = 0
+not_added = 0
 allsources = pd.read_csv(os.path.join(path, "Ultracool_Fundamental_Properties_Table.csv")) # Read entire table
 for i, source in allsources.iterrows():
     db_source = find_source_in_db(
@@ -32,13 +30,23 @@ for i, source in allsources.iterrows():
         ra_col_name="ra", 
         dec_col_name="dec"
     )
-    
+
     if db_source:
         alt_names = [source["name_simbadable"], source["name"]]
         for name in alt_names:
             if name != db_source[0] and name != "Null":
-                ingest_name(db, db_source[0], name.strip())
+                try:
+                    ingest_name(db, db_source[0], name.strip(), raise_error=True)
+                    names_added += 1
+                except AstroDBError as e:
+                    if "Other name is already present" in str(e):
+                        not_added += 1
+                    else:
+                        raise e
 
+print(
+    f"Added {names_added} names to the database, {not_added} names were already present."
+)  # 243, 559
 
 # Save to Database, Writes the JSON Files
 if save_db: 


### PR DESCRIPTION
I tweaked the ingest all names script a little bit to add counters.  This helps make sure everything is going to plan.

If when you run this, you get the same numbers I did (`Added 243 names to the database, 559 names were already present.`), then go ahead and add and commit the JSON files -- there should be 243!  Let's merge the alt names and then deal with the new sources in a new PR.